### PR TITLE
Add support for a ticket to be associated with a brand when it is created.

### DIFF
--- a/ZendeskApi_v2/Models/Tickets/Ticket.cs
+++ b/ZendeskApi_v2/Models/Tickets/Ticket.cs
@@ -83,7 +83,7 @@ namespace ZendeskApi_v2.Models.Tickets
         public SatisfactionRating SatisfactionRating { get; set; }
 
         [JsonProperty("brand_id")]
-        public int BrandId { get; set; }
+        public int? BrandId { get; set; }
       
         [JsonProperty("via")]
         public Via Via { get; set; }

--- a/ZendeskApi_v2/Models/Tickets/Ticket.cs
+++ b/ZendeskApi_v2/Models/Tickets/Ticket.cs
@@ -80,8 +80,10 @@ namespace ZendeskApi_v2.Models.Tickets
         public IList<CustomField> CustomFields { get; set; }
 
         [JsonProperty("satisfaction_rating")]
-        public SatisfactionRating SatisfactionRating { get; set; }            
-        
+        public SatisfactionRating SatisfactionRating { get; set; }
+
+        [JsonProperty("brand_id")]
+        public int BrandId { get; set; }
       
         [JsonProperty("via")]
         public Via Via { get; set; }

--- a/ZendeskApi_v2/Properties/AssemblyInfo.cs
+++ b/ZendeskApi_v2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("3.0.3.0")]
+[assembly: AssemblyFileVersion("3.0.3.0")]


### PR DESCRIPTION
The [Zendesk REST API documentation](https://developer.zendesk.com/rest_api/docs/core/tickets) details a `brand_id` JSON key for tickets. This can be used in enterprise accounts to assign a ticket to the specified brand. I have added this key as a property to the `Ticket` class so users of this API wrapper can take advantage of this feature.